### PR TITLE
Events: Show "Raise" button for Event subclasses

### DIFF
--- a/Assets/Code/Events/Editor/EventEditor.cs
+++ b/Assets/Code/Events/Editor/EventEditor.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace RoboRyanTron.Unite2017.Events
 {
-    [CustomEditor(typeof(GameEvent))]
+    [CustomEditor(typeof(GameEvent), editorForChildClasses: true)]
     public class EventEditor : Editor
     {
         public override void OnInspectorGUI()


### PR DESCRIPTION
Hi Ryan,

Thanks for your excellent talk and code samples. In my projects, I've found it helpful to subclass your `GameEvent` class, typically to allow passing data via events. For example, an `Announcement` could extend a `GameEvent` with additional properties (e.g. `string body`, `float duration`), as this is often cleaner than having separate `AnnouncementMessage` and `AnnouncementEvent` objects.

This PR allows your `EventEditor` custom editor to work on classes derived from `GameEvent` by passing the `editorForChildClasses` flag to Unity's `CustomEditor` decorator.

As far as I am aware, the change should not have any breaking changes and I suspect most people will not be aware of the difference :)